### PR TITLE
Code refactoring

### DIFF
--- a/animatedThemeManager/build.gradle
+++ b/animatedThemeManager/build.gradle
@@ -8,8 +8,10 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 4
+        minSdkVersion 16
         targetSdkVersion 30
+        versionCode 10
+        versionName "1.4"
     }
 
     buildTypes {

--- a/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/Coordinate.kt
+++ b/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/Coordinate.kt
@@ -1,3 +1,3 @@
 package com.dolatkia.animatedThemeManager
 
-class Coordinate(var x: Int, var y: Int)
+data class Coordinate(var x: Int, var y: Int)

--- a/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/ThemeActivity.kt
+++ b/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/ThemeActivity.kt
@@ -17,6 +17,11 @@ import androidx.appcompat.app.AppCompatActivity
 import kotlin.math.hypot
 
 abstract class ThemeActivity : AppCompatActivity() {
+
+    private val activityThemeManager: ThemeManager by lazy {
+        ThemeManager(this, getStartTheme())
+    }
+
     private lateinit var root: View
     private lateinit var frontFakeThemeImageView: ImageView
     private lateinit var behindFakeThemeImageView: ImageView
@@ -24,19 +29,13 @@ abstract class ThemeActivity : AppCompatActivity() {
     private var anim: Animator? = null
     private var themeAnimationListener: ThemeAnimationListener? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        ThemeManager.instance.init(this, getStartTheme())
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
-        super.onCreate(savedInstanceState, persistentState)
-        ThemeManager.instance.init(this, getStartTheme())
-    }
-
     override fun onStart() {
         super.onStart()
-        ThemeManager.instance.getCurrentTheme()?.let { syncTheme(it) }
+        activityThemeManager.getCurrentTheme()?.let { syncTheme(it) }
+    }
+
+    fun getThemeManager(): ThemeManager {
+        return activityThemeManager
     }
 
     override fun setContentView(@LayoutRes layoutResID: Int) {

--- a/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/ThemeFragment.kt
+++ b/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/ThemeFragment.kt
@@ -1,23 +1,30 @@
 package com.dolatkia.animatedThemeManager
 
-import android.os.Bundle
 import androidx.fragment.app.Fragment
 
 abstract class ThemeFragment : Fragment() {
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    private val fragmentThemeManager: ThemeManager? by lazy {
 
+        if(requireActivity() is ThemeActivity) {
+            (requireActivity() as ThemeActivity).getThemeManager()
+        } else {
+            null
+        }
     }
 
     override fun onResume() {
-        ThemeManager.instance.getCurrentLiveTheme().observe(this) {
+        fragmentThemeManager?.getCurrentLiveTheme()?.observe(this) {
             syncTheme(it)
         }
+
         super.onResume()
+    }
+
+    protected fun getThemeManager() : ThemeManager? {
+        return fragmentThemeManager
     }
 
     // to sync ui with selected theme
     abstract fun syncTheme(appTheme: AppTheme)
-
 }

--- a/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/ThemeManager.kt
+++ b/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/ThemeManager.kt
@@ -7,17 +7,11 @@ import android.view.View
 import android.view.WindowManager
 import androidx.lifecycle.MutableLiveData
 
-class ThemeManager {
+class ThemeManager(private val activity: ThemeActivity, defaultTheme: AppTheme) {
 
     private var liveTheme: MutableLiveData<AppTheme> = MutableLiveData()
-    private lateinit var activity: ThemeActivity
 
-    companion object {
-        val instance = ThemeManager()
-    }
-
-    fun init(activity: ThemeActivity, defaultTheme: AppTheme) {
-        this.activity = activity
+    init {
         liveTheme.value = defaultTheme
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
+    id 'kotlin-kapt'
 }
 
 android {
@@ -22,13 +23,18 @@ android {
         }
     }
 
-    dataBinding {
-        enabled = true
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    buildFeatures {
+        dataBinding true
     }
 }
 
 dependencies {
-//    implementation project(':animatedThemeManager')
-    implementation "com.dolatkia:animated-theme-manager:1.1.3"
+    implementation project(':animatedThemeManager')
+    //implementation "com.dolatkia:animated-theme-manager:1.1.3"
     implementation 'com.google.android.material:material:1.4.0'
 }

--- a/app/src/main/java/com/dolatkia/example/multiFragmentSample/MyFragment.kt
+++ b/app/src/main/java/com/dolatkia/example/multiFragmentSample/MyFragment.kt
@@ -53,13 +53,13 @@ class MyFragment : ThemeFragment() {
 
         // set change theme click listeners for buttons
         binder.lightButton.setOnClickListener {
-            ThemeManager.instance.changeTheme(LightTheme(), it)
+            getThemeManager()?.changeTheme(LightTheme(), it)
         }
         binder.nightButton.setOnClickListener {
-            ThemeManager.instance.changeTheme(NightTheme(), it)
+            getThemeManager()?.changeTheme(NightTheme(), it)
         }
         binder.pinkButton.setOnClickListener {
-            ThemeManager.instance.changeTheme(PinkTheme(), it)
+            getThemeManager()?.changeTheme(PinkTheme(), it)
         }
 
 
@@ -98,15 +98,15 @@ class MyFragment : ThemeFragment() {
         syncStatusBarIconColors(appTheme)
     }
 
-    fun syncStatusBarIconColors(theme: MyAppTheme) {
+    private fun syncStatusBarIconColors(theme: MyAppTheme) {
         activity?.let {
-            ThemeManager.instance.syncStatusBarIconsColorWithBackground(
+            getThemeManager()?.syncStatusBarIconsColorWithBackground(
                 it,
                 theme.activityBackgroundColor(it)
             )
         }
         activity?.let {
-            ThemeManager.instance.syncNavigationBarButtonsColorWithBackground(
+            getThemeManager()?.syncNavigationBarButtonsColorWithBackground(
                 it,
                 theme.activityBackgroundColor(it)
             )

--- a/app/src/main/java/com/dolatkia/example/multiFragmentSample/MyFragmentActivity.kt
+++ b/app/src/main/java/com/dolatkia/example/multiFragmentSample/MyFragmentActivity.kt
@@ -13,7 +13,7 @@ import com.dolatkia.example.themes.LightTheme
 
 class MyFragmentActivity : ThemeActivity() {
 
-    var fragmentNumber: Int = 0
+    private var fragmentNumber: Int = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/dolatkia/example/reverseSample/ReverseActivity.kt
+++ b/app/src/main/java/com/dolatkia/example/reverseSample/ReverseActivity.kt
@@ -1,7 +1,5 @@
 package com.dolatkia.example.reverseSample
 
-import android.animation.Animator
-import android.app.Activity
 import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -10,17 +8,15 @@ import com.dolatkia.animatedThemeManager.AppTheme
 import com.dolatkia.animatedThemeManager.ThemeActivity
 import com.dolatkia.animatedThemeManager.ThemeManager
 import com.dolatkia.example.databinding.ActivityReverseBinding
-import com.dolatkia.example.databinding.ActivitySingleBinding
 import com.dolatkia.example.themes.LightTheme
 import com.dolatkia.example.themes.MyAppTheme
 import com.dolatkia.example.themes.NightTheme
-import com.dolatkia.example.themes.PinkTheme
 
 
 class ReverseActivity : ThemeActivity() {
 
-    lateinit var binder: ActivityReverseBinding
-    var isNight = false
+    private lateinit var binder: ActivityReverseBinding
+    private var isNight = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -41,10 +37,10 @@ class ReverseActivity : ThemeActivity() {
         updateButtonText()
         binder.button.setOnClickListener {
             isNight = if(isNight){
-                ThemeManager.instance.reverseChangeTheme(LightTheme(), it)
+                getThemeManager().reverseChangeTheme(LightTheme(), it)
                 false
             }else{
-                ThemeManager.instance.changeTheme(NightTheme(), it)
+                getThemeManager().changeTheme(NightTheme(), it)
                 true
             }
             updateButtonText()
@@ -90,12 +86,12 @@ class ReverseActivity : ThemeActivity() {
         return LightTheme()
     }
 
-    fun syncStatusBarIconColors(theme: MyAppTheme) {
-        ThemeManager.instance.syncStatusBarIconsColorWithBackground(
+    private fun syncStatusBarIconColors(theme: MyAppTheme) {
+        getThemeManager().syncStatusBarIconsColorWithBackground(
             this,
             theme.activityBackgroundColor(this)
         )
-        ThemeManager.instance.syncNavigationBarButtonsColorWithBackground(
+        getThemeManager().syncNavigationBarButtonsColorWithBackground(
             this,
             theme.activityBackgroundColor(this)
         )

--- a/app/src/main/java/com/dolatkia/example/singleActivitySample/SingleActivity.kt
+++ b/app/src/main/java/com/dolatkia/example/singleActivitySample/SingleActivity.kt
@@ -1,7 +1,5 @@
 package com.dolatkia.example.singleActivitySample
 
-import android.animation.Animator
-import android.app.Activity
 import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -18,7 +16,7 @@ import com.dolatkia.example.themes.PinkTheme
 
 class SingleActivity : ThemeActivity() {
 
-    lateinit var binder: ActivitySingleBinding
+    private lateinit var binder: ActivitySingleBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -37,13 +35,13 @@ class SingleActivity : ThemeActivity() {
 
         // set change theme click listeners for buttons
         binder.lightButton.setOnClickListener {
-            ThemeManager.instance.changeTheme(LightTheme(), it)
+            getThemeManager().changeTheme(LightTheme(), it)
         }
         binder.nightButton.setOnClickListener {
-            ThemeManager.instance.changeTheme(NightTheme(), it)
+            getThemeManager().changeTheme(NightTheme(), it)
         }
         binder.pinkButton.setOnClickListener {
-            ThemeManager.instance.changeTheme(PinkTheme(), it)
+            getThemeManager().changeTheme(PinkTheme(), it)
         }
     }
 
@@ -80,12 +78,12 @@ class SingleActivity : ThemeActivity() {
         return LightTheme()
     }
 
-    fun syncStatusBarIconColors(theme: MyAppTheme) {
-        ThemeManager.instance.syncStatusBarIconsColorWithBackground(
+    private fun syncStatusBarIconColors(theme: MyAppTheme) {
+        getThemeManager().syncStatusBarIconsColorWithBackground(
             this,
             theme.activityBackgroundColor(this)
         )
-        ThemeManager.instance.syncNavigationBarButtonsColorWithBackground(
+        getThemeManager().syncNavigationBarButtonsColorWithBackground(
             this,
             theme.activityBackgroundColor(this)
         )

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.32"
+    ext.kotlin_version = "1.5.31"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.3"
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Following are the changes:

- companion object was not needed as an instance of ThemeManager can be created from outside
- The base activity is lazy creating their own instance of ThemeManager
- The base fragment is referring base activity to get hold of the ThemeManager by lazy
- Child classes of the activity and fragment can access the ThemeManager by calling getThemeManager()
- Kotlin version updated
- jcenter() has been replaced with mavenCentral()
- versionName and versionCode added to the library
- Java 8 support has been added in the gradle