### PR TITLE
Improved and Updated Code

### DIFF
--- a/animatedThemeManager/build.gradle
+++ b/animatedThemeManager/build.gradle
@@ -5,11 +5,11 @@ plugins {
 apply from: "${rootProject.projectDir}/scripts/publish-module.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 11
         versionName "1.1.4"
     }
@@ -23,5 +23,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.1"
 }

--- a/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/ThemeActivity.kt
+++ b/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/ThemeActivity.kt
@@ -18,10 +18,10 @@ import androidx.core.view.ViewCompat
 import kotlin.math.sqrt
 
 abstract class ThemeActivity : AppCompatActivity() {
-    private lateinit var root: View
-    private lateinit var frontFakeThemeImageView: SimpleImageView
-    private lateinit var behindFakeThemeImageView: SimpleImageView
-    private lateinit var decorView: FrameLayout
+    private var root: View? = null
+    private var frontFakeThemeImageView: SimpleImageView? = null
+    private var behindFakeThemeImageView: SimpleImageView? = null
+    private var decorView: FrameLayout? = null
 
     private var anim: Animator? = null
     private var themeAnimationListener: ThemeAnimationListener? = null
@@ -54,13 +54,17 @@ abstract class ThemeActivity : AppCompatActivity() {
     }
 
     override fun setContentView(view: View?) {
-        decorView.removeAllViews()
-        decorView.addView(view)
+        decorView?.let {
+            it.removeAllViews()
+            it.addView(view)
+        }
     }
 
     override fun setContentView(view: View?, params: ViewGroup.LayoutParams?) {
-        decorView.removeAllViews()
-        decorView.addView(view, params)
+        decorView?.let {
+            it.removeAllViews()
+            it.addView(view, params)
+        }
     }
 
     private fun initViews() {
@@ -115,19 +119,19 @@ abstract class ThemeActivity : AppCompatActivity() {
             return
         }
 
-        if (frontFakeThemeImageView.visibility == View.VISIBLE ||
-            behindFakeThemeImageView.visibility == View.VISIBLE ||
+        if (frontFakeThemeImageView?.visibility == View.VISIBLE ||
+            behindFakeThemeImageView?.visibility == View.VISIBLE ||
             isRunningChangeThemeAnimation()
         ) {
             return
         }
 
         // take screenshot
-        val w = decorView.measuredWidth
-        val h = decorView.measuredHeight
+        val w = decorView?.measuredWidth ?: 0
+        val h = decorView?.measuredHeight ?: 0
         val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
-        decorView.draw(canvas)
+        decorView?.draw(canvas)
 
         // update theme
         syncTheme(newTheme)
@@ -135,8 +139,8 @@ abstract class ThemeActivity : AppCompatActivity() {
         //create anim
         val finalRadius = sqrt((w * w + h * h).toDouble()).toFloat()
         if (isReverse) {
-            frontFakeThemeImageView.bitmap = bitmap
-            frontFakeThemeImageView.visibility = View.VISIBLE
+            frontFakeThemeImageView?.bitmap = bitmap
+            frontFakeThemeImageView?.visibility = View.VISIBLE
             anim = ViewAnimationUtils.createCircularReveal(
                 frontFakeThemeImageView,
                 sourceCoordinate.x,
@@ -145,8 +149,8 @@ abstract class ThemeActivity : AppCompatActivity() {
                 0f
             )
         } else {
-            behindFakeThemeImageView.bitmap = bitmap
-            behindFakeThemeImageView.visibility = View.VISIBLE
+            behindFakeThemeImageView?.bitmap = bitmap
+            behindFakeThemeImageView?.visibility = View.VISIBLE
             anim = ViewAnimationUtils.createCircularReveal(
                 decorView,
                 sourceCoordinate.x,
@@ -166,10 +170,10 @@ abstract class ThemeActivity : AppCompatActivity() {
             }
 
             override fun onAnimationEnd(animation: Animator) {
-                behindFakeThemeImageView.bitmap = null
-                frontFakeThemeImageView.bitmap = null
-                frontFakeThemeImageView.visibility = View.GONE
-                behindFakeThemeImageView.visibility = View.GONE
+                behindFakeThemeImageView?.bitmap = null
+                frontFakeThemeImageView?.bitmap = null
+                frontFakeThemeImageView?.visibility = View.GONE
+                behindFakeThemeImageView?.visibility = View.GONE
                 themeAnimationListener?.onAnimationEnd(animation)
             }
 
@@ -203,6 +207,10 @@ abstract class ThemeActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         themeManager.clearActivity()
+        frontFakeThemeImageView = null
+        behindFakeThemeImageView = null
+        root = null
+        decorView = null
         super.onDestroy()
     }
 

--- a/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/ThemeActivity.kt
+++ b/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/ThemeActivity.kt
@@ -28,27 +28,26 @@ abstract class ThemeActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
         super.onCreate(savedInstanceState, persistentState)
-        ThemeManager.instance.init(this, getStartTheme())
+        ThemeManager.init(this, getStartTheme())
         initViews()
         super.setContentView(root)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        ThemeManager.instance.init(this, getStartTheme())
+        ThemeManager.init(this, getStartTheme())
         initViews()
         super.setContentView(root)
     }
 
     override fun onResume() {
         super.onResume()
-        ThemeManager.instance.setActivity(this)
-        getThemeManager().getCurrentTheme()?.let { syncTheme(it) }
+        ThemeManager.setActivity(this)
+        themeManager.currentTheme?.let { syncTheme(it) }
     }
 
-    fun getThemeManager(): ThemeManager {
-        return ThemeManager.instance
-    }
+    protected val themeManager: ThemeManager
+        get() = ThemeManager
 
     override fun setContentView(@LayoutRes layoutResID: Int) {
         setContentView(LayoutInflater.from(this).inflate(layoutResID, decorView, false))
@@ -201,6 +200,11 @@ abstract class ThemeActivity : AppCompatActivity() {
     // to save the theme for the next time, save it in onDestroy() (exp: in pref or DB) and return it here.
     // it just used for the first time (first activity).
     abstract fun getStartTheme(): AppTheme
+
+    override fun onDestroy() {
+        themeManager.clearActivity()
+        super.onDestroy()
+    }
 
     companion object {
         //generated Id for decorView

--- a/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/ThemeFragment.kt
+++ b/animatedThemeManager/src/main/java/com/dolatkia/animatedThemeManager/ThemeFragment.kt
@@ -1,20 +1,29 @@
 package com.dolatkia.animatedThemeManager
 
+import android.os.Bundle
+import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.flow.filterNotNull
 
-abstract class ThemeFragment : Fragment() {
+abstract class ThemeFragment : Fragment {
 
-    override fun onResume() {
-        getThemeManager()?.getCurrentLiveTheme()?.observe(this) {
-            syncTheme(it)
+    constructor() : super() { }
+
+    constructor(@LayoutRes contentLayoutId: Int) : super(contentLayoutId)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        this.lifecycleScope.launchWhenResumed {
+            themeManager.theme.filterNotNull().collect {
+                syncTheme(it)
+            }
         }
 
-        super.onResume()
+        super.onCreate(savedInstanceState)
     }
 
-    protected fun getThemeManager() : ThemeManager? {
-        return ThemeManager.instance
-    }
+    protected val themeManager: ThemeManager
+        get() = ThemeManager
 
     // to sync ui with selected theme
     abstract fun syncTheme(appTheme: AppTheme)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,13 +5,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.dolatkia.example"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
     }
@@ -35,6 +35,6 @@ android {
 
 dependencies {
     implementation project(':animatedThemeManager')
-//    implementation "com.dolatkia:animated-theme-manager:1.1.4"
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.google.android.material:material:1.5.0'
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.1"
 }

--- a/app/src/main/java/com/dolatkia/example/multiFragmentSample/MyFragment.kt
+++ b/app/src/main/java/com/dolatkia/example/multiFragmentSample/MyFragment.kt
@@ -7,13 +7,14 @@ import android.view.ViewGroup
 import com.dolatkia.animatedThemeManager.AppTheme
 import com.dolatkia.animatedThemeManager.ThemeFragment
 import com.dolatkia.animatedThemeManager.ThemeManager
+import com.dolatkia.example.R
 import com.dolatkia.example.databinding.FragmentBinding
 import com.dolatkia.example.themes.LightTheme
 import com.dolatkia.example.themes.MyAppTheme
 import com.dolatkia.example.themes.NightTheme
 import com.dolatkia.example.themes.PinkTheme
 
-class MyFragment : ThemeFragment() {
+class MyFragment : ThemeFragment(R.layout.fragment) {
 
     private lateinit var binder: FragmentBinding
     private var number: Int = 0
@@ -34,16 +35,11 @@ class MyFragment : ThemeFragment() {
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
-        // create and bind views
-        binder = FragmentBinding.inflate(inflater)
+        binder = FragmentBinding.bind(view)
 
-        // set fragmentNumber
         binder.fragmentNumber.text = number.toString()
 
         //set next fragment click listener
@@ -53,18 +49,16 @@ class MyFragment : ThemeFragment() {
 
         // set change theme click listeners for buttons
         binder.lightButton.setOnClickListener {
-            ThemeManager.instance.changeTheme(LightTheme(), it)
+            themeManager.changeTheme(LightTheme(), it)
         }
         binder.nightButton.setOnClickListener {
-            ThemeManager.instance.changeTheme(NightTheme(), it)
+            themeManager.changeTheme(NightTheme(), it)
         }
         binder.pinkButton.setOnClickListener {
-            ThemeManager.instance.changeTheme(PinkTheme(), it)
+            themeManager.changeTheme(PinkTheme(), it)
         }
-
-
-        return binder.root
     }
+
 
     // to sync ui with selected theme
     override fun syncTheme(appTheme: AppTheme) {
@@ -100,13 +94,13 @@ class MyFragment : ThemeFragment() {
 
     private fun syncStatusBarIconColors(theme: MyAppTheme) {
         activity?.let {
-            ThemeManager.instance.syncStatusBarIconsColorWithBackground(
+            themeManager.syncStatusBarIconsColorWithBackground(
                 it,
                 theme.activityBackgroundColor(it)
             )
         }
         activity?.let {
-            ThemeManager.instance.syncNavigationBarButtonsColorWithBackground(
+            themeManager.syncNavigationBarButtonsColorWithBackground(
                 it,
                 theme.activityBackgroundColor(it)
             )

--- a/app/src/main/java/com/dolatkia/example/reverseSample/ReverseActivity.kt
+++ b/app/src/main/java/com/dolatkia/example/reverseSample/ReverseActivity.kt
@@ -35,14 +35,10 @@ class ReverseActivity : ThemeActivity() {
         // set change theme click listeners for buttons
         updateButtonText()
         binder.button.setOnClickListener {
-            if (ThemeManager.instance.getCurrentTheme()
-                    ?.id() == NightTheme.ThemeId
-            ) {
-                ThemeManager.instance.reverseChangeTheme(LightTheme(), it)
-            } else if (ThemeManager.instance.getCurrentTheme()
-                    ?.id() != NightTheme.ThemeId
-            ) {
-                ThemeManager.instance.changeTheme(NightTheme(), it)
+            if (themeManager.currentTheme?.id() == NightTheme.ThemeId) {
+                themeManager.reverseChangeTheme(LightTheme(), it)
+            } else if (themeManager.currentTheme?.id() != NightTheme.ThemeId) {
+                themeManager.changeTheme(NightTheme(), it)
             }
             updateButtonText()
         }
@@ -74,7 +70,7 @@ class ReverseActivity : ThemeActivity() {
     }
 
     fun updateButtonText() {
-        if (ThemeManager.instance.getCurrentTheme()?.id() == NightTheme.ThemeId) {
+        if (themeManager.currentTheme?.id() == NightTheme.ThemeId) {
             binder.buttonTextView.text = "Light"
         } else {
             binder.buttonTextView.text = "Night"
@@ -87,11 +83,11 @@ class ReverseActivity : ThemeActivity() {
     }
 
     private fun syncStatusBarIconColors(theme: MyAppTheme) {
-        ThemeManager.instance.syncStatusBarIconsColorWithBackground(
+        themeManager.syncStatusBarIconsColorWithBackground(
             this,
             theme.activityBackgroundColor(this)
         )
-        ThemeManager.instance.syncNavigationBarButtonsColorWithBackground(
+        themeManager.syncNavigationBarButtonsColorWithBackground(
             this,
             theme.activityBackgroundColor(this)
         )

--- a/app/src/main/java/com/dolatkia/example/singleActivitySample/SingleActivity.kt
+++ b/app/src/main/java/com/dolatkia/example/singleActivitySample/SingleActivity.kt
@@ -3,8 +3,10 @@ package com.dolatkia.example.singleActivitySample
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.WindowManager
+import androidx.lifecycle.lifecycleScope
 import com.dolatkia.animatedThemeManager.AppTheme
 import com.dolatkia.animatedThemeManager.ThemeActivity
 import com.dolatkia.animatedThemeManager.ThemeManager
@@ -13,6 +15,7 @@ import com.dolatkia.example.themes.LightTheme
 import com.dolatkia.example.themes.MyAppTheme
 import com.dolatkia.example.themes.NightTheme
 import com.dolatkia.example.themes.PinkTheme
+import kotlinx.coroutines.flow.filterNotNull
 
 
 class SingleActivity : ThemeActivity() {
@@ -43,18 +46,23 @@ class SingleActivity : ThemeActivity() {
 
         // set change theme click listeners for buttons
         binder.lightButton.setOnClickListener {
-            ThemeManager.instance.changeTheme(LightTheme(), it)
+            themeManager.changeTheme(LightTheme(), it)
         }
         binder.nightButton.setOnClickListener {
-            ThemeManager.instance.changeTheme(NightTheme(), it)
+            themeManager.changeTheme(NightTheme(), it)
         }
         binder.pinkButton.setOnClickListener {
-            ThemeManager.instance.changeTheme(PinkTheme(), it)
+            themeManager.changeTheme(PinkTheme(), it)
         }
         binder.nextActivityBtn.setOnClickListener {
             val myIntent = Intent(this, SingleActivity::class.java)
             myIntent.putExtra("number", number + 1)
             this.startActivity(myIntent)
+        }
+        lifecycleScope.launchWhenStarted {
+            themeManager.theme.filterNotNull().collect {
+                Log.i("Changed Theme", "Using theme with id: ${it.id()}")
+            }
         }
     }
 
@@ -93,11 +101,11 @@ class SingleActivity : ThemeActivity() {
     }
 
     private fun syncStatusBarIconColors(theme: MyAppTheme) {
-        ThemeManager.instance.syncStatusBarIconsColorWithBackground(
+        themeManager.syncStatusBarIconsColorWithBackground(
             this,
             theme.activityBackgroundColor(this)
         )
-        ThemeManager.instance.syncNavigationBarButtonsColorWithBackground(
+        themeManager.syncNavigationBarButtonsColorWithBackground(
             this,
             theme.activityBackgroundColor(this)
         )

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.31"
+    ext.kotlin_version = "1.6.20"
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
This PR contains multiple changes.

- ThemeManager class has been changed to an object (as it has been used in an object like way before).
- Previous ThemeManager had a potential memory leak of the activity, this has been fixed by wrapping it in a WeakReference.
- ThemeActivity had potential memory leaks of views, this has been fixed.
- Fragments can pass the layout in their constructor which partly fixes #14 (I don't think the same thing is possible for activities)
- LiveData containing the theme has been changed to a StateFlow for more flexibility
- Added ```@JvmOverloads``` on some functions for better Java compatibility
- Replaced some get methods with final variables and getter


## 📄 Motivation and Context
- Fixes some potential memory leaks.
- Improved flexibility, usage and compatibility

 I've made those changes because it was not nice to use with unnecessary get methods and depending on LiveData as it's not flexible enough for my usecase.
Additionally I could not pass the layout inside the Fragment constructor what I normally do #14.

## 🧪 How Has This Been Tested?
I've tested it using an emulator, opend every activity and navigated further (e.g. next activity or next fragment).
No crash occurred and it works as expected.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
Fixed memory leaks

- [x] New feature (non-breaking change which adds functionality)
Pass layout in Fragment constructor and overload functions for Java

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Replaced LiveData with Flow and replaced some methods with variables
ThemeManager is an object now what means no ```instance``` call on it

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
